### PR TITLE
chore: prepare v0.2.8 release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,5 +117,6 @@ winget:
     ids:
       - archive
 
-
-
+release:
+  github:
+    draft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.7] - 2026-05-01
+## [0.2.8] - 2026-05-01
 ### Fixed
 - Restored cross-repo publishing for Homebrew, Scoop, and Winget.
 - Finalized CI/CD workflow with correct permissions.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.2.7"
+var Version = "0.2.8"


### PR DESCRIPTION
Bumping version to v0.2.8 and forcing draft release mode to ensure GoReleaser can upload assets before finalizing the release.