### PR TITLE
ci: resolve Node.js 20 deprecation warnings by updating actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24.2'
         check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.24.2'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.2'
           cache: true


### PR DESCRIPTION
This PR resolves the Node.js 20 deprecation warnings by updating the GitHub Actions to their latest versions that support Node.js 24.

Changes:
- Updated `actions/setup-go` from `v5` to `v6` across all workflows (`test.yml`, `codeql.yml`, `release.yml`).
- Standardized Go version to `1.24.2` in `release.yml` (was `1.22`) to match `go.mod` and other workflows.

These updates ensure compatibility with upcoming GitHub Actions runner changes and remove the deprecation warnings from the build logs.